### PR TITLE
KaTeX 0.16.4 update + fixed symbols encoded as HTML entities not being understood by KaTeX

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,11 @@ Change Log
 -----------
 
 
+**Version 0.3.2:**
+
+- Fix issue where special characters such as ampersands (e.g. used in a latex `matrix`` environment for alignment) would be resolved to HTML elements and confuse KaTeX.
+- Updated to use KaTeX 0.16.4. 
+
 **Version 0.3:**
 
 - Support line breaks (Add :code:`\newline` inside your math equations)
@@ -116,7 +121,7 @@ Change Log
    :target: https://ammsa.github.io/django-latexify
 .. |quality| image:: https://img.shields.io/codacy/grade/d8e71ce5a26248d892e96e35fdf1f7cf.svg?maxAge=2592000
    :target: https://www.codacy.com/app/ammsa7/django-latexify?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=AmmsA/django-latexify&amp;utm_campaign=Badge_Grade
-.. |maintain| image:: https://img.shields.io/maintenance/yes/2017.svg
+.. |maintain| image:: https://img.shields.io/maintenance/yes/2023.svg
    :target: https://github.com/ammsa/django-latexify
 .. |python3| image:: https://img.shields.io/badge/python3-yes-brightgreen.svg
    :target: https://github.com/ammsa/django-latexify

--- a/latexify/templates/latexify/scripts.html
+++ b/latexify/templates/latexify/scripts.html
@@ -15,7 +15,7 @@
     function latex_render_math(elements, displayMode){
         for (var i = 0; i < elements.length; ++i) {
             var element = elements[i];
-            var math_eq = element.innerHTML;
+            var math_eq = element.textContent;
             katex.render(math_eq, element, {displayMode: displayMode,
                                             throwOnError: false,
                                             errorColor: '#bf2626'});

--- a/latexify/templates/latexify/scripts.html
+++ b/latexify/templates/latexify/scripts.html
@@ -1,5 +1,5 @@
 {% load latexify %}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.0/katex.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/katex@0.16.4/dist/katex.min.js"></script>
 <script>
 
     var math_latex_inline_elements = document.getElementsByClassName('{% value_from_settings "LATEX_MATH_INLINE_CSS_CLASS" %}');

--- a/latexify/templates/latexify/stylesheets.html
+++ b/latexify/templates/latexify/stylesheets.html
@@ -1,3 +1,3 @@
 {% load static %}
 <link rel="stylesheet" href="{% static "latexify/css/latex.css" %}"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.0/katex.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.4/dist/katex.min.css">

--- a/latexify/tests.py
+++ b/latexify/tests.py
@@ -171,3 +171,9 @@ class LatexifyTests(TestCase):
             context = {}
             output = ''
             self.tag_test(template, context, output)
+    
+    def test__real_ampersand(self):
+        template = '{% latexify test_text %}'
+        context = {'test_text': '&'}
+        output = '<span class="django-latexify text">&</span>'
+        self.tag_test(template, context, output)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-latexify',
-    version='0.3.1',
+    version='0.3.2',
     packages=['latexify'],
     install_requires=[],
     include_package_data=True,
@@ -20,7 +20,7 @@ setup(
     author='Mustafa S',
     author_email='mabualsaud@outlook.com',
     maintainer='Charlie Wimmer',
-    maintainer_email='do-not-mail-me@fakemail.invalid',
+    maintainer_email='31413434+CDWimmer@users.noreply.github.com',
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
@@ -32,6 +32,10 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-latexify',
-    version='0.3.1',
+    version='0.3.2',
     packages=['latexify'],
     install_requires=[],
     include_package_data=True,
@@ -20,7 +20,7 @@ setup(
     author='Mustafa S',
     author_email='mabualsaud@outlook.com',
     maintainer='Charlie Wimmer',
-    maintainer_email='do-not-mail-me@fakemail.invalid',
+    maintainer_email='31413434+CDWimmer@users.noreply.github.com',
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-latexify',
-    version='0.3',
+    version='0.3.1',
     packages=['latexify'],
     install_requires=[],
     include_package_data=True,
@@ -19,6 +19,8 @@ setup(
     url='https://github.com/AmmsA/django-latexify',
     author='Mustafa S',
     author_email='mabualsaud@outlook.com',
+    maintainer='Charlie Wimmer',
+    maintainer_email='do-not-mail-me@fakemail.invalid',
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-latexify',
-    version='0.3.2',
+    version='0.3.1',
     packages=['latexify'],
     install_requires=[],
     include_package_data=True,
@@ -20,7 +20,7 @@ setup(
     author='Mustafa S',
     author_email='mabualsaud@outlook.com',
     maintainer='Charlie Wimmer',
-    maintainer_email='31413434+CDWimmer@users.noreply.github.com',
+    maintainer_email='do-not-mail-me@fakemail.invalid',
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',


### PR DESCRIPTION
1) I've swapped the URLs to refer to KaTeX 0.16.4 minified script and CSS rather than the absolutely ancient 0.11.0.

2) A similar issue was resolved in KaTeX's auto-renderer extension a while back (discussed [here](https://github.com/jfcere/ngx-markdown/issues/243)), and I found an older suggestion on SO [here](https://stackoverflow.com/a/53754842/9311137).

django-latexify doesn't use KaTeX's auto-renderer, instead injecting its own script to tell KaTeX what to render. This is fine, except that it uses `.innerHTML`, which incorrectly returns ampersands as the string "`&amp;`" which KaTeX makes a mess of, hence the result seen here: https://github.com/ammsa/django-latexify/issues/6. 

The fix for this was, following the above SO guidance, to swap `innerHTML` for `textContent`, which correctly returns the string "&" and allows KaTeX to act as expected.

3) I've attempted to write a test for this change but I've never written a test before so please review!